### PR TITLE
KIDS 1227 Include the mediumId in child transaction

### DIFF
--- a/lib/features/giving_flow/create_transaction/models/transaction.dart
+++ b/lib/features/giving_flow/create_transaction/models/transaction.dart
@@ -2,12 +2,14 @@ class Transaction {
   const Transaction({
     required this.userId,
     required this.collectGroupId,
+    required this.mediumId,
     this.donationType = DonationType.AdHocDonation,
     required this.amount,
   });
 
   final String userId;
   final String collectGroupId;
+  final String mediumId;
   final DonationType donationType;
   final double amount;
 
@@ -15,6 +17,7 @@ class Transaction {
     return {
       'userId': userId,
       'collectGroupId': collectGroupId,
+      'mediumId': mediumId,
       'donationType': donationType.name,
       'amount': amount,
     };

--- a/lib/features/giving_flow/organisation_details/cubit/organisation_details_cubit.dart
+++ b/lib/features/giving_flow/organisation_details/cubit/organisation_details_cubit.dart
@@ -16,7 +16,8 @@ class OrganisationDetailsCubit extends Cubit<OrganisationDetailsState> {
     try {
       final response =
           await _organisationRepository.fetchOrganosationDetails(qrCode);
-      emit(OrganisationDetailsSetState(organisation: response));
+      emit(OrganisationDetailsSetState(
+          organisation: response, mediumId: qrCode));
     } catch (error) {
       emit(const OrganisationDetailsErrorState());
     }

--- a/lib/features/giving_flow/organisation_details/cubit/organisation_details_state.dart
+++ b/lib/features/giving_flow/organisation_details/cubit/organisation_details_state.dart
@@ -1,11 +1,13 @@
 part of 'organisation_details_cubit.dart';
 
 abstract class OrganisationDetailsState extends Equatable {
-  const OrganisationDetailsState({required this.organisation});
+  const OrganisationDetailsState(
+      {required this.organisation, this.mediumId = ''});
   final OrganisationDetails organisation;
+  final String mediumId;
 
   @override
-  List<Object> get props => [organisation];
+  List<Object> get props => [organisation, mediumId];
 }
 
 class OrganisationDetailsInitialState extends OrganisationDetailsState {
@@ -20,5 +22,6 @@ class OrganisationDetailsErrorState extends OrganisationDetailsState {
 }
 
 class OrganisationDetailsSetState extends OrganisationDetailsState {
-  const OrganisationDetailsSetState({required super.organisation});
+  const OrganisationDetailsSetState(
+      {required super.organisation, required super.mediumId});
 }

--- a/lib/features/giving_flow/screens/choose_amount_slider_screen.dart
+++ b/lib/features/giving_flow/screens/choose_amount_slider_screen.dart
@@ -41,6 +41,8 @@ class _ChooseAmountSliderScreenState extends State<ChooseAmountSliderScreen> {
   Widget build(BuildContext context) {
     final OrganisationDetails organisation =
         context.read<OrganisationDetailsCubit>().state.organisation;
+    final String mediumId =
+        context.read<OrganisationDetailsCubit>().state.mediumId;
     return BlocProvider<CreateTransactionCubit>(
       create: (BuildContext context) =>
           CreateTransactionCubit(_profilesCubit, getIt()),
@@ -207,6 +209,7 @@ class _ChooseAmountSliderScreenState extends State<ChooseAmountSliderScreen> {
                             var transaction = Transaction(
                               userId: _profilesCubit.state.activeProfile.id,
                               collectGroupId: organisation.collectGroupId,
+                              mediumId: mediumId,
                               amount: state.amount,
                             );
 


### PR DESCRIPTION
Pass the mediumId from the Qr code into the transaction.
Requested by BE in order to determine determine how the transaction was made(Qr, list, beacon, etc)