### PR TITLE
Feature/ kids 1538 in app coin flow fixes

### DIFF
--- a/lib/core/app/app_router.dart
+++ b/lib/core/app/app_router.dart
@@ -70,12 +70,12 @@ class AppRouter {
           path: Pages.chooseAmountSlider.path,
           name: Pages.chooseAmountSlider.name,
           builder: (context, state) {
-            final String mediumID =
-                state.uri.queryParameters['code']!.contains('null')
-                    ? OrganisationDetailsCubit.defaultMediumId
-                    : state.uri.queryParameters['code']!;
-
             if (getIt<SharedPreferences>().getBool('isInAppCoinFlow') == true) {
+              final String mediumID =
+                  state.uri.queryParameters['code'] == null ||
+                          state.uri.queryParameters['code']!.contains('null')
+                      ? OrganisationDetailsCubit.defaultMediumId
+                      : state.uri.queryParameters['code']!;
               context
                   .read<OrganisationDetailsCubit>()
                   .getOrganisationDetails(mediumID);

--- a/lib/features/scan_nfc/cubit/scan_nfc_cubit.dart
+++ b/lib/features/scan_nfc/cubit/scan_nfc_cubit.dart
@@ -15,8 +15,8 @@ class ScanNfcCubit extends Cubit<ScanNfcState> {
             coinAnimationStatus: CoinAnimationStatus.initial,
             scanNFCStatus: ScanNFCStatus.initial));
 
-  static const startDelay = Duration(milliseconds: 3000);
-  static const foundDelay = Duration(milliseconds: 3000);
+  static const startDelay = Duration(milliseconds: 1800);
+  static const foundDelay = Duration(milliseconds: 1800);
 
   void cancelScanning() {
     emit(state.copyWith(

--- a/lib/features/scan_nfc/nfc_scan_screen.dart
+++ b/lib/features/scan_nfc/nfc_scan_screen.dart
@@ -124,7 +124,9 @@ class NFCScanPage extends StatelessWidget {
               // on iOS user dismissing the bottomsheet cannot be detected
               // so we need to show the button always after the start of scanning
               : Platform.isIOS && state.scanNFCStatus == ScanNFCStatus.scanning
-                  ? const StartScanNfcButton()
+                  ? FutureBuilder(
+                      future: Future.delayed(const Duration(seconds: 1)),
+                      builder: (c, s) => const StartScanNfcButton())
                   : null,
           floatingActionButtonLocation:
               FloatingActionButtonLocation.centerFloat,


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

- Quicker bottomsheet appearance and redirection
- Delay the appearance of the 'Start' button on iOS (the button is redrawn quicker than the system initiates the NFC scanning vottomsheet)
- Fix null value check