### PR TITLE
Make ChooseAmountSliderScreen the same in 2 instances

### DIFF
--- a/lib/core/app/app_router.dart
+++ b/lib/core/app/app_router.dart
@@ -7,6 +7,7 @@ import 'package:givt_app_kids/features/auth/screens/login_screen.dart';
 import 'package:givt_app_kids/features/coin_flow/cubit/search_coin_cubit.dart';
 import 'package:givt_app_kids/features/coin_flow/screens/search_for_coin_screen.dart';
 import 'package:givt_app_kids/features/coin_flow/screens/success_coin_screen.dart';
+import 'package:givt_app_kids/features/flows/cubit/flows_cubit.dart';
 import 'package:givt_app_kids/features/giving_flow/organisation_details/cubit/organisation_details_cubit.dart';
 import 'package:givt_app_kids/features/giving_flow/screens/choose_amount_slider_screen.dart';
 import 'package:givt_app_kids/features/giving_flow/screens/success_screen.dart';
@@ -20,7 +21,6 @@ import 'package:givt_app_kids/features/recommendation/cubit/recommendation_cubit
 import 'package:givt_app_kids/features/recommendation/recommendation_screen.dart';
 import 'package:givt_app_kids/features/scan_nfc/cubit/scan_nfc_cubit.dart';
 import 'package:givt_app_kids/features/scan_nfc/nfc_scan_screen.dart';
-import 'package:givt_app_kids/helpers/snack_bar_helper.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -70,24 +70,7 @@ class AppRouter {
         GoRoute(
           path: Pages.chooseAmountSlider.path,
           name: Pages.chooseAmountSlider.name,
-          builder: (context, state) {
-            // WidgetsBinding.instance.addPostFrameCallback((_) {
-            //   context.pop();
-            // });
-            // // this only needs to execute when the user is
-            // // coming via deeplink in the inAppCoinFlow
-            // if (state.uri.host == 'http://www.givt.app/') {
-            //   final String mediumID =
-            //       state.uri.queryParameters['code'] == null ||
-            //               state.uri.queryParameters['code']!.contains('null')
-            //           ? OrganisationDetailsCubit.defaultMediumId
-            //           : state.uri.queryParameters['code']!;
-            //   context
-            //       .read<OrganisationDetailsCubit>()
-            //       .getOrganisationDetails(mediumID);
-            // }
-            return const ChooseAmountSliderScreen();
-          },
+          builder: (context, state) => const ChooseAmountSliderScreen(),
         ),
         GoRoute(
           path: Pages.success.path,
@@ -134,21 +117,19 @@ class AppRouter {
               ? null
               : "${Pages.outAppCoinFlow.path}?code=${state.uri.queryParameters['code']}",
           builder: (context, state) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              SnackBarHelper.showMessage(
-                context,
-                text: "${state.uri.host}\n${state.uri.scheme}",
-              );
-              // context.pop();
-            });
             final String mediumID = state.uri.queryParameters['code'] == null ||
                     state.uri.queryParameters['code']!.contains('null')
                 ? OrganisationDetailsCubit.defaultMediumId
                 : state.uri.queryParameters['code']!;
+            // Because the deeplink opens a whole new app context we need to
+            // re-fetch the organisation details
+            // & emit the in-app coin flow
 
             context
                 .read<OrganisationDetailsCubit>()
                 .getOrganisationDetails(mediumID);
+
+            context.read<FlowsCubit>().startInAppCoinFlow();
 
             return const ChooseAmountSliderScreen();
           },

--- a/lib/shared/widgets/givt_back_button.dart
+++ b/lib/shared/widgets/givt_back_button.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:givt_app_kids/core/app/pages.dart';
+import 'package:givt_app_kids/features/flows/cubit/flow_type.dart';
+import 'package:givt_app_kids/features/flows/cubit/flows_cubit.dart';
 
 import 'package:givt_app_kids/helpers/analytics_helper.dart';
 import 'package:givt_app_kids/helpers/app_theme.dart';
@@ -14,13 +18,17 @@ class GivtBackButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final flow = context.read<FlowsCubit>().state;
+    final isDeeplinkInApp =
+        (!context.canPop() && flow.flowType == FlowType.inAppCoin);
+    final isVisible = context.canPop() || isDeeplinkInApp;
     return Container(
       alignment: Alignment.topLeft,
       padding: const EdgeInsets.only(left: 15, top: 15),
       child: Opacity(
-        opacity: context.canPop() ? 1 : 0,
+        opacity: isVisible ? 1 : 0,
         child: AbsorbPointer(
-          absorbing: !context.canPop(),
+          absorbing: !isVisible,
           child: CircleAvatar(
             radius: 20,
             backgroundColor: AppTheme.backButtonColor,
@@ -31,7 +39,10 @@ class GivtBackButton extends StatelessWidget {
 
                 AnalyticsHelper.logEvent(
                     eventName: AmplitudeEvent.backButtonPressed);
-
+                if (isDeeplinkInApp) {
+                  context.goNamed(Pages.wallet.name);
+                  return;
+                }
                 context.pop();
               },
               icon: const Icon(


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

There are now 2 builders for the ChooseAmountSliderScreen; 
One in app, and the other if an android user activates the deeplink while inAppCoinFlow;
This PR makes them look exactly the same by:
- Emitting the correct flows state
- Remove the snackbar notifier
- Adding the back button