### PR TITLE
Bug:kids-210 start nfc button iphone issue

### DIFF
--- a/lib/core/app/app_router.dart
+++ b/lib/core/app/app_router.dart
@@ -233,8 +233,8 @@ class AppRouter {
           name: Pages.scanNFC.name,
           builder: (context, state) {
             return BlocProvider(
-              create: (context) =>
-                  ScanNfcCubit()..readTag(delay: ScanNfcCubit.startDelay),
+              create: (context) => ScanNfcCubit()
+                ..readTag(prescanningDelay: ScanNfcCubit.startDelay),
               child: const NFCScanPage(),
             );
           },

--- a/lib/features/scan_nfc/cubit/scan_nfc_state.dart
+++ b/lib/features/scan_nfc/cubit/scan_nfc_state.dart
@@ -2,6 +2,7 @@ part of 'scan_nfc_cubit.dart';
 
 enum ScanNFCStatus {
   ready,
+  prescanning,
   scanning,
   scanned,
   error,

--- a/lib/features/scan_nfc/nfc_scan_screen.dart
+++ b/lib/features/scan_nfc/nfc_scan_screen.dart
@@ -97,7 +97,10 @@ class NFCScanPage extends StatelessWidget {
             backgroundColor: Colors.transparent,
             elevation: 0,
             leading: GivtBackButton(
-              onPressedExt: () => context.read<FlowsCubit>().resetFlow(),
+              onPressedExt: () {
+                context.read<FlowsCubit>().resetFlow();
+                context.read<ScanNfcCubit>().cancelScanning();
+              },
             ),
           ),
           body: SafeArea(


### PR DESCRIPTION
## Description
- In app coin flow is fixed for Android; 
- nfc scanning session ends when user presses back button on the Scan NFC page; 
- 'Found it!' text removed from iphone scanning bottomsheet