### PR TITLE
Improvement: kid- 129 precache recommendation images

### DIFF
--- a/lib/core/injection/injection.dart
+++ b/lib/core/injection/injection.dart
@@ -10,6 +10,7 @@ import 'package:givt_app_kids/features/history/history_logic/history_repository.
 import 'package:givt_app_kids/features/profiles/repository/profiles_repository.dart';
 import 'package:givt_app_kids/features/recommendation/organisations/repositories/organisations_repository.dart';
 import 'package:givt_app_kids/features/recommendation/tags/repositories/tags_repository.dart';
+import 'package:givt_app_kids/helpers/svg_manager.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final getIt = GetIt.instance;
@@ -73,5 +74,8 @@ void _initRepositories() {
       () => OrganisationsRepositoryImpl(
         getIt(),
       ),
+    )
+    ..registerLazySingleton<SvgAssetLoaderManager>(
+      () => SvgAssetLoaderManager(),
     );
 }

--- a/lib/core/network/token_interceptor.dart
+++ b/lib/core/network/token_interceptor.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:developer';
 
 // import 'package:givt_app/app/injection/injection.dart';
 // import 'package:givt_app/core/logging/logging.dart';

--- a/lib/features/profiles/screens/wallet_screen.dart
+++ b/lib/features/profiles/screens/wallet_screen.dart
@@ -67,9 +67,12 @@ class _WalletScreenState extends State<WalletScreen>
 
   Future<bool> isIpadCheck() async {
     DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
-    IosDeviceInfo info = await deviceInfo.iosInfo;
-    if (info.model.isNotEmpty && info.model.toLowerCase().contains("ipad")) {
-      return true;
+    if (deviceInfo.deviceInfo is IosDeviceInfo) {
+      IosDeviceInfo info = await deviceInfo.iosInfo;
+      if (info.model.isNotEmpty && info.model.toLowerCase().contains("ipad")) {
+        return true;
+      }
+      return false;
     }
     return false;
   }

--- a/lib/features/recommendation/interests/screens/interests_selection_screen.dart
+++ b/lib/features/recommendation/interests/screens/interests_selection_screen.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app_kids/core/app/pages.dart';
+import 'package:givt_app_kids/core/injection/injection.dart';
 import 'package:givt_app_kids/features/recommendation/interests/cubit/interests_cubit.dart';
 import 'package:givt_app_kids/features/recommendation/interests/widgets/interest_card.dart';
 import 'package:givt_app_kids/features/recommendation/interests/widgets/interests_tally.dart';
 import 'package:givt_app_kids/features/recommendation/widgets/recommendation_givy_bubble.dart';
+import 'package:givt_app_kids/helpers/svg_manager.dart';
 import 'package:givt_app_kids/shared/widgets/givt_back_button.dart';
 import 'package:givt_app_kids/shared/widgets/givt_elevated_button.dart';
 
@@ -18,6 +20,8 @@ class InterestsSelectionScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<InterestsCubit, InterestsState>(
       builder: (context, state) {
+        final svgManager = getIt<SvgAssetLoaderManager>();
+
         return Scaffold(
           extendBodyBehindAppBar: true,
           appBar: AppBar(
@@ -71,6 +75,8 @@ class InterestsSelectionScreen extends StatelessWidget {
                         (BuildContext context, int index) {
                           return InterestCard(
                             interest: state.interests[index],
+                            picture: svgManager.buildSvgPicture(
+                                state.interests[index].pictureUrl),
                             isSelected: state.selectedInterests
                                 .contains(state.interests[index]),
                             onPressed: () {

--- a/lib/features/recommendation/interests/widgets/interest_card.dart
+++ b/lib/features/recommendation/interests/widgets/interest_card.dart
@@ -6,12 +6,14 @@ import 'package:givt_app_kids/helpers/app_theme.dart';
 class InterestCard extends StatelessWidget {
   const InterestCard({
     required this.interest,
+    required this.picture,
     required this.onPressed,
     this.isSelected = false,
     super.key,
   });
 
   final Tag interest;
+  final SvgPicture picture;
   final void Function() onPressed;
   final bool isSelected;
 
@@ -54,10 +56,7 @@ class InterestCard extends StatelessWidget {
                   Expanded(
                     flex: 5,
                     child: Center(
-                      child: SizedBox.square(
-                        dimension: 80,
-                        child: SvgPicture.network(interest.pictureUrl),
-                      ),
+                      child: picture,
                     ),
                   ),
                   Expanded(

--- a/lib/features/recommendation/tags/screens/location_selection_screen.dart
+++ b/lib/features/recommendation/tags/screens/location_selection_screen.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app_kids/core/app/pages.dart';
+import 'package:givt_app_kids/core/injection/injection.dart';
 import 'package:givt_app_kids/features/recommendation/tags/cubit/tags_cubit.dart';
 import 'package:givt_app_kids/features/recommendation/tags/models/tag.dart';
 import 'package:givt_app_kids/features/recommendation/tags/widgets/location_card.dart';
 import 'package:givt_app_kids/features/recommendation/widgets/recommendation_givy_bubble.dart';
+import 'package:givt_app_kids/helpers/svg_manager.dart';
 import 'package:givt_app_kids/shared/widgets/givt_back_button.dart';
 import 'package:givt_app_kids/shared/widgets/givt_elevated_button.dart';
 import 'package:go_router/go_router.dart';
@@ -17,6 +19,7 @@ class LocationSelectionScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<TagsCubit, TagsState>(
       builder: (context, state) {
+        final svgManager = getIt<SvgAssetLoaderManager>();
         return Scaffold(
           extendBodyBehindAppBar: true,
           appBar: AppBar(
@@ -105,7 +108,7 @@ class LocationSelectionScreen extends StatelessWidget {
                   text: "Next",
                   onTap: state is TagsStateFetched &&
                           state.selectedLocation != const Tag.empty()
-                      ? () {
+                      ? () async {
                           context.pushNamed(
                             Pages.interestsSelection.name,
                             extra: state,
@@ -114,6 +117,9 @@ class LocationSelectionScreen extends StatelessWidget {
                                 location: const Tag.empty(),
                                 logAmplitude: false,
                               );
+                          await svgManager.preloadSvgAssets(state.interests
+                              .map((e) => e.pictureUrl)
+                              .toList());
                         }
                       : null,
                 )

--- a/lib/features/recommendation/tags/screens/location_selection_screen.dart
+++ b/lib/features/recommendation/tags/screens/location_selection_screen.dart
@@ -108,7 +108,7 @@ class LocationSelectionScreen extends StatelessWidget {
                   text: "Next",
                   onTap: state is TagsStateFetched &&
                           state.selectedLocation != const Tag.empty()
-                      ? () async {
+                      ? () {
                           svgManager.preloadSvgAssets(state.interests
                               .map((e) => e.pictureUrl)
                               .toList());

--- a/lib/features/recommendation/tags/screens/location_selection_screen.dart
+++ b/lib/features/recommendation/tags/screens/location_selection_screen.dart
@@ -109,6 +109,9 @@ class LocationSelectionScreen extends StatelessWidget {
                   onTap: state is TagsStateFetched &&
                           state.selectedLocation != const Tag.empty()
                       ? () async {
+                          svgManager.preloadSvgAssets(state.interests
+                              .map((e) => e.pictureUrl)
+                              .toList());
                           context.pushNamed(
                             Pages.interestsSelection.name,
                             extra: state,
@@ -117,9 +120,6 @@ class LocationSelectionScreen extends StatelessWidget {
                                 location: const Tag.empty(),
                                 logAmplitude: false,
                               );
-                          await svgManager.preloadSvgAssets(state.interests
-                              .map((e) => e.pictureUrl)
-                              .toList());
                         }
                       : null,
                 )

--- a/lib/helpers/svg_manager.dart
+++ b/lib/helpers/svg_manager.dart
@@ -15,9 +15,7 @@ class SvgAssetLoaderManager {
 
   Future<void> preloadSvgAssets(List<String> pictureUrls) async {
     for (final url in pictureUrls) {
-      final loader = getLoader(url);
-      await svg.cache
-          .putIfAbsent(loader.cacheKey(null), () => loader.loadBytes(null));
+      getLoader(url);
     }
   }
 

--- a/lib/helpers/svg_manager.dart
+++ b/lib/helpers/svg_manager.dart
@@ -13,7 +13,7 @@ class SvgAssetLoaderManager {
     }
   }
 
-  Future<void> preloadSvgAssets(List<String> pictureUrls) async {
+  void preloadSvgAssets(List<String> pictureUrls) {
     for (final url in pictureUrls) {
       getLoader(url);
     }

--- a/lib/helpers/svg_manager.dart
+++ b/lib/helpers/svg_manager.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_svg/flutter_svg.dart';
+
+class SvgAssetLoaderManager {
+  final Map<String, SvgAssetLoader> _loaders = {};
+
+  SvgAssetLoader getLoader(String pictureUrl) {
+    if (_loaders.containsKey(pictureUrl)) {
+      return _loaders[pictureUrl]!;
+    } else {
+      final loader = SvgAssetLoader(pictureUrl);
+      _loaders[pictureUrl] = loader;
+      return loader;
+    }
+  }
+
+  Future<void> preloadSvgAssets(List<String> pictureUrls) async {
+    for (final url in pictureUrls) {
+      final loader = getLoader(url);
+      await svg.cache
+          .putIfAbsent(loader.cacheKey(null), () => loader.loadBytes(null));
+    }
+  }
+
+  SvgPicture buildSvgPicture(String pictureUrl) {
+    final loader = getLoader(pictureUrl);
+    return SvgPicture.network(loader.assetName);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -226,10 +226,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "6ff9fa12892ae074092de2fa6a9938fb21dbabfdaa2ff57dc697ff912fc8d4b2"
+      sha256: d39e7f95621fc84376bc0f7d504f05c3a41488c562f4a8ad410569127507402c
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.6"
+    version: "2.0.9"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -456,14 +456,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
-  path_drawing:
-    dependency: transitive
-    description:
-      name: path_drawing
-      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   path_parsing:
     dependency: transitive
     description:
@@ -733,6 +725,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  vector_graphics:
+    dependency: transitive
+    description:
+      name: vector_graphics
+      sha256: "18f6690295af52d081f6808f2f7c69f0eed6d7e23a71539d75f4aeb8f0062172"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.9+2"
+  vector_graphics_codec:
+    dependency: transitive
+    description:
+      name: vector_graphics_codec
+      sha256: "531d20465c10dfac7f5cd90b60bbe4dd9921f1ec4ca54c83ebb176dbacb7bb2d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.9+2"
+  vector_graphics_compiler:
+    dependency: transitive
+    description:
+      name: vector_graphics_compiler
+      sha256: "03012b0a33775c5530576b70240308080e1d5050f0faf000118c20e6463bc0ad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.9+2"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   equatable: ^2.0.5
   flutter_bloc: ^8.1.3
-  flutter_svg: ^1.1.6
+  flutter_svg: ^2.0.0+1
   get_it: ^7.6.4
   go_router: ^10.1.2
   http: ^0.13.5


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
- Pre-compile all interest svgs while navigating to the next page

FYI: The approach described on the flutter_svg package page for[ precompiling and optimizing SVGs](https://pub.dev/packages/flutter_svg#precompiling-and-optimizing-svgs) is outdated. 
You can see the exact example they provide in the package as an issue [here](https://github.com/dnfield/flutter_svg/issues/844)
