### PR TITLE
Improvement: kids-412 Reward banner animation duration reduced to 600ms; Animation curve ch…

### DIFF
--- a/lib/shared/widgets/reward_banner_dialog.dart
+++ b/lib/shared/widgets/reward_banner_dialog.dart
@@ -11,11 +11,11 @@ class RewardBannerDialog extends StatefulWidget {
 
 class _RewardBannerDialogState extends State<RewardBannerDialog>
     with SingleTickerProviderStateMixin {
-  static const Duration _animationDuration = Duration(milliseconds: 1500);
+  static const Duration _animationDuration = Duration(milliseconds: 600);
   static const Duration _showingBannerInitialDelay =
       Duration(milliseconds: 300);
   static const Duration _showingBannerDuration = Duration(milliseconds: 3000);
-  static const Curve _animationCurve = Curves.elasticOut;
+  static const Curve _animationCurve = Curves.easeInOutBack;
 
   late final AnimationController _controller = AnimationController(
     duration: _animationDuration,


### PR DESCRIPTION
## Description
- Reward banner animation duration reduced to 600ms (from 1500ms); 
- Animation curve changed to easeInOutBack;

