### PR TITLE
Bug: KIDS-537 Refresh goal and profiles on route

### DIFF
--- a/lib/core/app/app_router.dart
+++ b/lib/core/app/app_router.dart
@@ -62,7 +62,6 @@ class AppRouter {
             final profiles = context.read<ProfilesCubit>().state;
             if (auth is LoggedInState) {
               if (profiles.isProfileSelected) {
-                context.read<ProfilesCubit>().fetchActiveProfile();
                 return Pages.wallet.path;
               }
               context.read<ProfilesCubit>().fetchAllProfiles();
@@ -82,14 +81,16 @@ class AppRouter {
           builder: (context, state) => const ProfileSelectionScreen(),
         ),
         GoRoute(
-          path: Pages.wallet.path,
-          name: Pages.wallet.name,
-          builder: (context, state) => BlocProvider(
-            create: (context) => GoalTrackerCubit(getIt())
-              ..getGoal(context.read<ProfilesCubit>().state.activeProfile.id),
-            child: const WalletScreen(),
-          ),
-        ),
+            path: Pages.wallet.path,
+            name: Pages.wallet.name,
+            builder: (context, state) {
+              final profiles = context.read<ProfilesCubit>().state;
+              context.read<ProfilesCubit>().fetchActiveProfile();
+              context
+                  .read<GoalTrackerCubit>()
+                  .getGoal(profiles.activeProfile.id);
+              return const WalletScreen();
+            }),
         GoRoute(
           path: Pages.camera.path,
           name: Pages.camera.name,

--- a/lib/features/family_goal_tracker/widgets/goal_active_widget.dart
+++ b/lib/features/family_goal_tracker/widgets/goal_active_widget.dart
@@ -12,7 +12,8 @@ class GoalActiveWidget extends StatelessWidget {
     final state = context.read<GoalTrackerCubit>().state;
     final currentGoal = state.currentGoal;
     final progress = currentGoal.amount / currentGoal.goalAmount.toDouble();
-    final totalProgress = currentGoal.totalAmount / currentGoal.goalAmount.toDouble();
+    final totalProgress =
+        currentGoal.totalAmount / currentGoal.goalAmount.toDouble();
     return Padding(
       padding: const EdgeInsets.only(left: 56, right: 56, top: 24),
       child: Column(

--- a/lib/features/giving_flow/screens/choose_amount_slider_goal_screen.dart
+++ b/lib/features/giving_flow/screens/choose_amount_slider_goal_screen.dart
@@ -1,12 +1,10 @@
 import 'dart:developer';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:givt_app_kids/core/app/pages.dart';
-import 'package:givt_app_kids/features/family_goal_tracker/cubit/goal_tracker_cubit.dart';
 import 'package:givt_app_kids/features/family_goal_tracker/model/family_goal.dart';
 import 'package:givt_app_kids/features/giving_flow/create_transaction/cubit/create_transaction_cubit.dart';
 import 'package:givt_app_kids/features/giving_flow/organisation_details/cubit/organisation_details_cubit.dart';
@@ -28,7 +26,6 @@ class ChooseAmountSliderGoalScreen extends StatelessWidget {
     final organisationDetailsState =
         context.watch<OrganisationDetailsCubit>().state;
     final profilesCubit = context.read<ProfilesCubit>();
-    final goalTrackerCubit = context.read<GoalTrackerCubit>();
     final organisation = organisationDetailsState.organisation;
     final mediumId = organisationDetailsState.mediumId;
     final amountLeftToGoal = familyGoal.goalAmount - familyGoal.amount;
@@ -41,12 +38,6 @@ class ChooseAmountSliderGoalScreen extends StatelessWidget {
               text: 'Cannot create transaction. Please try again later.',
               isError: true);
         } else if (state is CreateTransactionSuccessState) {
-          // Execute tasks in parallel
-          await Future.wait([
-            profilesCubit.fetchActiveProfile(),
-            goalTrackerCubit.getGoal(profilesCubit.state.activeProfile.id)
-          ]);
-
           if (!context.mounted) {
             return;
           }

--- a/lib/features/giving_flow/screens/choose_amount_slider_screen.dart
+++ b/lib/features/giving_flow/screens/choose_amount_slider_screen.dart
@@ -40,7 +40,6 @@ class ChooseAmountSliderScreen extends StatelessWidget {
               text: 'Cannot create transaction. Please try again later.',
               isError: true);
         } else if (state is CreateTransactionSuccessState) {
-          profilesCubit.fetchActiveProfile();
           context.pushReplacementNamed(
             flow.isExhibition
                 ? Pages.successExhibitionCoin.name

--- a/lib/features/profiles/screens/profile_selection_screen.dart
+++ b/lib/features/profiles/screens/profile_selection_screen.dart
@@ -36,7 +36,6 @@ class ProfileSelectionScreen extends StatelessWidget {
           GestureDetector(
             onTap: () {
               context.read<ProfilesCubit>().fetchProfile(profiles[i].id, true);
-
               AnalyticsHelper.logEvent(
                 eventName: AmplitudeEvent.profilePressed,
                 eventProperties: {

--- a/lib/features/profiles/widgets/give_bottomsheet.dart
+++ b/lib/features/profiles/widgets/give_bottomsheet.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -43,7 +42,8 @@ class GiveBottomSheet extends StatelessWidget {
                       onTap: () {
                         context.pop();
                         context.read<FlowsCubit>().startFamilyGoalFlow();
-                        String generatedMediumId = base64.encode(familyGoal.mediumId.codeUnits);
+                        String generatedMediumId =
+                            base64.encode(familyGoal.mediumId.codeUnits);
                         context
                             .read<OrganisationDetailsCubit>()
                             .getOrganisationDetails(generatedMediumId);


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Bug core cause: There were 2 providers of GoalTrackerCubit, so with a second donation it was emitting state on the "wrong" instance.

Fix:
- remove 2nd instance of goaltrackercubut
- move the responsibility of re-fetching profiles and goal on the route. This way we don't have to "remember" to do this step before navigation. 