### PR TITLE
Feature: KIDS-565 School event flow skeleton is implemented 

### DIFF
--- a/lib/core/app/app_router.dart
+++ b/lib/core/app/app_router.dart
@@ -38,6 +38,9 @@ import 'package:givt_app_kids/features/recommendation/tags/cubit/tags_cubit.dart
 import 'package:givt_app_kids/features/recommendation/tags/screens/location_selection_screen.dart';
 import 'package:givt_app_kids/features/scan_nfc/cubit/scan_nfc_cubit.dart';
 import 'package:givt_app_kids/features/scan_nfc/nfc_scan_screen.dart';
+import 'package:givt_app_kids/features/school_event/screens/family_name_login_screen.dart';
+import 'package:givt_app_kids/features/school_event/screens/school_event_info_screen.dart';
+import 'package:givt_app_kids/features/school_event/screens/school_event_organisations_screen.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -277,8 +280,8 @@ class AppRouter {
           },
         ),
         GoRoute(
-          path: Pages.voucherCodeScreen.path,
-          name: Pages.voucherCodeScreen.name,
+          path: Pages.voucherCode.path,
+          name: Pages.voucherCode.name,
           builder: (context, state) => const VoucherCodeScreen(),
         ),
         GoRoute(
@@ -303,6 +306,36 @@ class AppRouter {
           name: Pages.successExhibitionCoin.name,
           builder: (context, state) =>
               const exhibition_flow.SuccessCoinScreen(),
+        ),
+        GoRoute(
+          path: Pages.familyNameLogin.path,
+          name: Pages.familyNameLogin.name,
+          builder: (context, state) => const FamilyNameLoginScreen(),
+        ),
+        GoRoute(
+          path: Pages.schoolEventInfo.path,
+          name: Pages.schoolEventInfo.name,
+          builder: (context, state) => const SchoolEventInfoScreen(),
+        ),
+        GoRoute(
+          path: Pages.schoolEventOrganisations.path,
+          name: Pages.schoolEventOrganisations.name,
+          builder: (context, state) {
+            return BlocProvider(
+              create: (context) => OrganisationsCubit(
+                getIt(),
+              )
+                //TODO: replace with proper method when endpoint be ready
+                // ..getSchoolEventOrganisations(),
+                ..getRecommendedOrganisations(
+                  location: OrganisationsCubit.exhibitionLocation,
+                  interests: OrganisationsCubit.exhibitionInterests,
+                  pageSize: 6,
+                  filterInterests: false,
+                ),
+              child: const SchoolEventOrganisationsScreen(),
+            );
+          },
         ),
         GoRoute(
           path: Pages.avatarSelection.path,
@@ -330,8 +363,8 @@ class AppRouter {
           },
         ),
         GoRoute(
-          path: Pages.designAlignmentScreen.path,
-          name: Pages.designAlignmentScreen.name,
+          path: Pages.designAlignment.path,
+          name: Pages.designAlignment.name,
           builder: (context, state) => const DesignAlignmentScreen(),
         ),
       ]);

--- a/lib/core/app/pages.dart
+++ b/lib/core/app/pages.dart
@@ -26,18 +26,23 @@ enum Pages {
   redirectPopPage(path: '/redirect-pop-page', name: 'REDIRECT_POP_PAGE'),
 
   //exhibition flow
-  voucherCodeScreen(path: '/voucher-code-screen', name: 'VOUCHER_CODE_SCREEN'),
+  voucherCode(path: '/voucher-code', name: 'VOUCHER_CODE'),
   exhibitionOrganisations(
       path: '/exhibition-organisations', name: 'EXHIBITION_ORGANISATIONS'),
   successExhibitionCoin(
       path: '/success-exhibition-coin', name: 'SUCCESS_EXHIBITION_COIN'),
 
   //design alignment
-  designAlignmentScreen(
-      path: '/design-alignment-screen', name: 'DESIGN_ALIGNMENT_SCREEN'),
+  designAlignment(path: '/design-alignment', name: 'DESIGN_ALIGNMENT'),
 
   chooseAmountSliderGoal(
       path: '/choose-amount-slider-goal', name: 'CHOOSE_AMOUNT_SLIDER_GOAL'),
+
+//school event mode
+  familyNameLogin(path: '/family-name-login', name: 'FAMILY_NAME_LOGIN'),
+  schoolEventInfo(path: '/school-event-info', name: 'SCHOOL_EVENT_INFO'),
+  schoolEventOrganisations(
+      path: '/school-event-organisations', name: 'SCHOOL_EVENT_ORGANISATIONS'),
   ;
 
   final String path;

--- a/lib/core/network/api_service.dart
+++ b/lib/core/network/api_service.dart
@@ -67,6 +67,26 @@ class APIService {
     }
   }
 
+  Future<Map<String, dynamic>> loginByFamilyName(
+      Map<String, dynamic> body) async {
+    final url = Uri.https(_apiURL, '/givt4kidsservice/v1/Authentication/event');
+
+    var response = await client.post(
+      url,
+      headers: {"Content-Type": "application/json"},
+      body: jsonEncode(body),
+    );
+
+    if (response.statusCode >= 400) {
+      throw GivtServerException(
+        statusCode: response.statusCode,
+        body: jsonDecode(response.body) as Map<String, dynamic>,
+      );
+    } else {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    }
+  }
+
   Future<List<dynamic>> fetchAllProfiles() async {
     final url = Uri.https(_apiURL, '/givt4kidsservice/v1/profiles');
 
@@ -216,6 +236,23 @@ class APIService {
       headers: {"Content-Type": "application/json"},
       body: jsonEncode(body),
     );
+
+    if (response.statusCode >= 400) {
+      throw GivtServerException(
+        statusCode: response.statusCode,
+        body: jsonDecode(response.body) as Map<String, dynamic>,
+      );
+    } else {
+      var decodedBody = json.decode(response.body);
+      var itemsList = decodedBody['items'] as List<dynamic>;
+      return itemsList;
+    }
+  }
+
+  Future<List<dynamic>> getSchoolEventOrganisations() async {
+    final url = Uri.https(_apiURL, '/givt4kidsservice/v1/organisation/event');
+
+    var response = await client.get(url);
 
     if (response.statusCode >= 400) {
       throw GivtServerException(

--- a/lib/features/auth/cubit/auth_state.dart
+++ b/lib/features/auth/cubit/auth_state.dart
@@ -89,21 +89,36 @@ class ExternalErrorState extends AuthState {
 }
 
 class LoggedInState extends AuthState {
+  static const int _currentVersion = 1;
+  static const String _versionKey = '_versionKey';
+
   const LoggedInState({
-    this.session = const Session.empty(),
+    this.schoolEventMode = false,
   });
 
-  final Session session;
+  final bool schoolEventMode;
+
+  bool get isSchoolEvenMode {
+    return schoolEventMode;
+  }
 
   factory LoggedInState.fromJson(Map<String, dynamic> json) {
-    return LoggedInState(
-      session: Session.fromJson(json),
-    );
+    //versioning to prevent user logout when app be updated
+    final version = getIt<SharedPreferences>().getInt(_versionKey);
+    switch (version) {
+      case _currentVersion:
+        return LoggedInState(schoolEventMode: json['schoolEventMode']);
+      default:
+        return const LoggedInState();
+    }
   }
 
   @override
   Map<String, dynamic> toJson() {
-    return session.toJson();
+    getIt<SharedPreferences>().setInt(_versionKey, _currentVersion);
+    return {
+      'schoolEventMode': schoolEventMode,
+    };
   }
 }
 

--- a/lib/features/auth/models/auth_request.dart
+++ b/lib/features/auth/models/auth_request.dart
@@ -1,30 +1,42 @@
 class AuthRequest {
-  AuthRequest({
+  const AuthRequest({
     required this.email,
     required this.password,
     required this.type,
     required this.voucherCode,
+    required this.familyName,
   });
 
-  AuthRequest.email({
+  const AuthRequest.email({
     required this.email,
     required this.password,
   })  : type = LoginType.email,
-        voucherCode = '';
+        voucherCode = '',
+        familyName = '';
 
-  AuthRequest.voucher({
+  const AuthRequest.voucher({
     required this.voucherCode,
   })  : type = LoginType.voucher,
         email = '',
-        password = '';
+        password = '',
+        familyName = '';
+
+  const AuthRequest.family({
+    required this.familyName,
+  })  : type = LoginType.family,
+        email = '',
+        password = '',
+        voucherCode = '';
 
   final String email;
   final String password;
   final LoginType type;
   final String voucherCode;
+  final String familyName;
 }
 
 enum LoginType {
   email,
   voucher,
+  family,
 }

--- a/lib/features/auth/models/auth_request.dart
+++ b/lib/features/auth/models/auth_request.dart
@@ -23,7 +23,7 @@ class AuthRequest {
 
   const AuthRequest.family({
     required this.familyName,
-  })  : type = LoginType.family,
+  })  : type = LoginType.event,
         email = '',
         password = '',
         voucherCode = '';
@@ -38,5 +38,5 @@ class AuthRequest {
 enum LoginType {
   email,
   voucher,
-  family,
+  event,
 }

--- a/lib/features/auth/repositories/auth_repository.dart
+++ b/lib/features/auth/repositories/auth_repository.dart
@@ -41,6 +41,13 @@ class AuthRepositoryImpl with AuthRepository {
           },
         );
         break;
+      case LoginType.family:
+        response = await _apiService.loginByFamilyName(
+          {
+            'familyName': authRequest.familyName,
+          },
+        );
+        break;
     }
 
     final sessionJson = response['item'];

--- a/lib/features/auth/repositories/auth_repository.dart
+++ b/lib/features/auth/repositories/auth_repository.dart
@@ -41,7 +41,7 @@ class AuthRepositoryImpl with AuthRepository {
           },
         );
         break;
-      case LoginType.family:
+      case LoginType.event:
         response = await _apiService.loginByFamilyName(
           {
             'familyName': authRequest.familyName,

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:developer';
 
+import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app_kids/core/app/pages.dart';
@@ -104,7 +105,7 @@ class _LoginScreenState extends State<LoginScreen> {
                         GestureDetector(
                           onDoubleTap: () {
                             context.read<FlowsCubit>().startExhibitionFlow();
-                            context.pushNamed(Pages.voucherCodeScreen.name);
+                            context.pushNamed(Pages.voucherCode.name);
                           },
                           child: Text(
                             'Welcome',
@@ -135,14 +136,13 @@ class _LoginScreenState extends State<LoginScreen> {
                     children: [
                       Text(
                         "Email",
-                        style:
-                            Theme.of(context).textTheme.titleSmall?.copyWith(
-                                  color: (state is InputFieldErrorState &&
-                                          state.emailErrorMessage.isNotEmpty)
-                                      ? Theme.of(context).colorScheme.error
-                                      : AppTheme.defaultTextColor,
-                                  fontWeight: FontWeight.bold,
-                                ),
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                              color: (state is InputFieldErrorState &&
+                                      state.emailErrorMessage.isNotEmpty)
+                                  ? Theme.of(context).colorScheme.error
+                                  : AppTheme.defaultTextColor,
+                              fontWeight: FontWeight.bold,
+                            ),
                       ),
                       const SizedBox(height: 5),
                       TextField(
@@ -176,10 +176,7 @@ class _LoginScreenState extends State<LoginScreen> {
                       const SizedBox(height: 15),
                       Text(
                         "Password",
-                        style: Theme.of(context)
-                            .textTheme
-                            .titleSmall
-                            ?.copyWith(
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
                               color: (state is InputFieldErrorState &&
                                           state.passwordErrorMessage
                                               .isNotEmpty ||
@@ -259,6 +256,19 @@ class _LoginScreenState extends State<LoginScreen> {
                     ],
                   ),
                   const SizedBox(height: 24),
+                  //TODO: replace with specific toggle later on
+                  if (FirebaseRemoteConfig.instance
+                      .getBool('example_feature_enabled'))
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 24),
+                      child: GivtElevatedButton(
+                        text: 'School event flow',
+                        onTap: () {
+                          context.goNamed(Pages.familyNameLogin.name);
+                        },
+                      ),
+                    ),
+
                   GivtElevatedButton(
                     text: 'Sign in',
                     isLoading: state is LoadingState,

--- a/lib/features/coin_flow/screens/success_coin_screen.dart
+++ b/lib/features/coin_flow/screens/success_coin_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:givt_app_kids/core/app/pages.dart';
+import 'package:givt_app_kids/features/auth/cubit/auth_cubit.dart';
 import 'package:givt_app_kids/features/flows/cubit/flows_cubit.dart';
 import 'package:givt_app_kids/features/profiles/cubit/profiles_cubit.dart';
 import 'package:givt_app_kids/helpers/analytics_helper.dart';
@@ -47,7 +48,7 @@ class _SuccessCoinScreenState extends State<SuccessCoinScreen> {
             children: [
               Positioned.fill(
                 child: Lottie.asset(
-                  "assets/lotties/coin_success_2.json",
+                  'assets/lotties/coin_success_2.json',
                   fit: BoxFit.fitWidth,
                   alignment: Alignment.bottomCenter,
                   width: double.infinity,
@@ -62,13 +63,14 @@ class _SuccessCoinScreenState extends State<SuccessCoinScreen> {
   }
 
   Widget _buildSuccessText() {
+    final authState = context.read<AuthCubit>().state as LoggedInState;
     return Positioned.fill(
       child: Padding(
         padding: const EdgeInsets.only(left: 20, right: 20, top: 70),
         child: Column(
           children: [
             Text(
-              widget.isGoal ? "Well done!" : "Activated!",
+              widget.isGoal ? 'Well done!' : 'Activated!',
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     color: AppTheme.defaultTextColor,
@@ -79,8 +81,10 @@ class _SuccessCoinScreenState extends State<SuccessCoinScreen> {
             ),
             Text(
               widget.isGoal
-                  ? "You helped towards your family goal!"
-                  : "Drop your coin wherever your\nchurch collects money.",
+                  ? 'You helped towards your family goal!'
+                  : authState.isSchoolEvenMode
+                      ? 'Drop your coin in\nthe groups giving box.'
+                      : 'Drop your coin wherever your\nchurch collects money.',
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                     color: AppTheme.defaultTextColor,
@@ -95,7 +99,7 @@ class _SuccessCoinScreenState extends State<SuccessCoinScreen> {
   Widget _buildFAB(bool isOnlyChild) {
     if (widget.isGoal) {
       return GivtElevatedButton(
-        text: "Done",
+        text: 'Done',
         onTap: () {
           context.goNamed(Pages.wallet.name);
           context.read<FlowsCubit>().resetFlow();

--- a/lib/features/profiles/widgets/wallet_widget.dart
+++ b/lib/features/profiles/widgets/wallet_widget.dart
@@ -67,8 +67,7 @@ class _WalletWidgetState extends State<WalletWidget> {
                                 packageInfo.packageName.contains('test');
                             if (isDebug) {
                               // ignore: use_build_context_synchronously
-                              context
-                                  .pushNamed(Pages.designAlignmentScreen.name);
+                              context.pushNamed(Pages.designAlignment.name);
                             }
                           },
                           onTap: () {

--- a/lib/features/recommendation/organisations/cubit/organisations_cubit.dart
+++ b/lib/features/recommendation/organisations/cubit/organisations_cubit.dart
@@ -91,4 +91,21 @@ class OrganisationsCubit extends Cubit<OrganisationsState> {
       emit(OrganisationsExternalErrorState(errorMessage: error.toString()));
     }
   }
+
+  Future<void> getSchoolEventOrganisations() async {
+    emit(const OrganisationsFetchingState());
+
+    try {
+      final response =
+          await _organisationsRepository.getSchoolEventOrganisations();
+
+      emit(OrganisationsFetchedState(organisations: response));
+    } catch (error, stackTrace) {
+      LoggingInfo.instance.error(
+        'Error while fetching school event organisations: $error',
+        methodName: stackTrace.toString(),
+      );
+      emit(OrganisationsExternalErrorState(errorMessage: error.toString()));
+    }
+  }
 }

--- a/lib/features/recommendation/organisations/repositories/organisations_repository.dart
+++ b/lib/features/recommendation/organisations/repositories/organisations_repository.dart
@@ -10,6 +10,8 @@ mixin OrganisationsRepository {
     required bool filterInterests,
     required String cityName,
   });
+
+  Future<List<Organisation>> getSchoolEventOrganisations();
 }
 
 class OrganisationsRepositoryImpl with OrganisationsRepository {
@@ -44,6 +46,18 @@ class OrganisationsRepositoryImpl with OrganisationsRepository {
             !interests.contains(tag) && tag.type == TagType.INTERESTS ||
             location.key != tag.key && tag.type == TagType.LOCATION);
       }
+      result.add(organisation);
+    }
+    return result;
+  }
+
+  @override
+  Future<List<Organisation>> getSchoolEventOrganisations() async {
+    final response = await _apiService.getSchoolEventOrganisations();
+
+    List<Organisation> result = [];
+    for (final organisationMap in response) {
+      final organisation = Organisation.fromMap(organisationMap);
       result.add(organisation);
     }
     return result;

--- a/lib/features/scan_nfc/nfc_scan_screen.dart
+++ b/lib/features/scan_nfc/nfc_scan_screen.dart
@@ -27,6 +27,7 @@ class NFCScanPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final flow = context.read<FlowsCubit>().state;
     final user = context.read<ProfilesCubit>().state.activeProfile;
+    final auth = context.read<AuthCubit>().state as LoggedInState;
     return BlocConsumer<ScanNfcCubit, ScanNfcState>(
       listener: (context, state) {
         final scanNfcCubit = context.read<ScanNfcCubit>();
@@ -56,7 +57,10 @@ class NFCScanPage extends StatelessWidget {
                                   .read<OrganisationDetailsCubit>()
                                   .state is OrganisationDetailsLoadingState,
                               onPressed: () {
-                                if (flow.isExhibition) {
+                                if (auth.isSchoolEvenMode) {
+                                  context.pushReplacementNamed(
+                                      Pages.schoolEventOrganisations.name);
+                                } else if (flow.isExhibition) {
                                   context.pushReplacementNamed(
                                       Pages.exhibitionOrganisations.name);
                                 } else {
@@ -82,7 +86,9 @@ class NFCScanPage extends StatelessWidget {
               .read<OrganisationDetailsCubit>()
               .getOrganisationDetails(state.mediumId);
           Future.delayed(ScanNfcCubit.foundDelay, () {
-            if (flow.isExhibition) {
+            if (auth.isSchoolEvenMode) {
+              context.pushReplacementNamed(Pages.schoolEventOrganisations.name);
+            } else if (flow.isExhibition) {
               context.pushReplacementNamed(Pages.exhibitionOrganisations.name);
             } else {
               context.pushReplacementNamed(Pages.chooseAmountSlider.name);

--- a/lib/features/school_event/screens/family_name_login_screen.dart
+++ b/lib/features/school_event/screens/family_name_login_screen.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:givt_app_kids/core/app/pages.dart';
+import 'package:givt_app_kids/features/auth/cubit/auth_cubit.dart';
+import 'package:givt_app_kids/features/profiles/cubit/profiles_cubit.dart';
+import 'package:givt_app_kids/features/profiles/models/profile.dart';
+import 'package:givt_app_kids/helpers/snack_bar_helper.dart';
+import 'package:givt_app_kids/shared/widgets/givt_back_button.dart';
+import 'package:givt_app_kids/shared/widgets/givt_elevated_button.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:google_fonts/google_fonts.dart';
+
+class FamilyNameLoginScreen extends StatefulWidget {
+  const FamilyNameLoginScreen({super.key});
+
+  @override
+  State<FamilyNameLoginScreen> createState() => _FamilyNameLoginScreenState();
+}
+
+class _FamilyNameLoginScreenState extends State<FamilyNameLoginScreen> {
+  String _familyName = '';
+
+  void _showErrorMessage() {
+    SnackBarHelper.showMessage(
+      context,
+      text: 'Cannot login with family name. Please try again later.',
+      isError: true,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    return BlocConsumer<AuthCubit, AuthState>(
+      listener: (context, authState) {
+        if (authState is ExternalErrorState) {
+          _showErrorMessage();
+        } else if (authState is LoggedInState) {
+          context.read<ProfilesCubit>().fetchAllProfiles();
+        }
+      },
+      builder: (context, authState) {
+        return BlocConsumer<ProfilesCubit, ProfilesState>(
+          listener: (context, propfilesState) {
+            if (propfilesState is ProfilesExternalErrorState) {
+              _showErrorMessage();
+            } else if (propfilesState is ProfilesUpdatedState &&
+                propfilesState.activeProfile == Profile.empty()) {
+              context
+                  .read<ProfilesCubit>()
+                  .fetchProfile(propfilesState.profiles[0].id);
+
+              context.goNamed(Pages.schoolEventInfo.name);
+            }
+          },
+          builder: (context, propfilesState) {
+            return Scaffold(
+              appBar: AppBar(
+                leading: GivtBackButton(
+                  onPressedForced: () => context.goNamed(Pages.login.name),
+                ),
+              ),
+              body: authState is LoadingState ||
+                      propfilesState is ProfilesLoadingState
+                  ? const Center(child: CircularProgressIndicator())
+                  : SafeArea(
+                      child: SizedBox.expand(
+                        child: SingleChildScrollView(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              SizedBox(height: size.height * 0.1),
+                              Text(
+                                "Let's begin!",
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .titleLarge
+                                    ?.copyWith(fontWeight: FontWeight.w700),
+                              ),
+                              const SizedBox(height: 5),
+                              Text(
+                                'Enter your family name',
+                                style: GoogleFonts.mulish(
+                                  textStyle:
+                                      Theme.of(context).textTheme.titleLarge,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                              SizedBox(height: size.height * 0.15),
+                              Padding(
+                                padding:
+                                    const EdgeInsets.symmetric(horizontal: 50),
+                                child: TextField(
+                                  textInputAction: TextInputAction.done,
+                                  keyboardType: TextInputType.name,
+                                  onChanged: (value) {
+                                    setState(() {
+                                      _familyName = value.trim();
+                                    });
+                                  },
+                                ),
+                              ),
+                              SizedBox(height: size.height * 0.10),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+              floatingActionButtonLocation:
+                  FloatingActionButtonLocation.centerFloat,
+              floatingActionButton: authState is! LoadingState &&
+                      propfilesState is! ProfilesLoadingState
+                  ? GivtElevatedButton(
+                      text: 'Next',
+                      isDisabled:
+                          _familyName.length < AuthCubit.familyNameMinLength,
+                      onTap: () {
+                        context
+                            .read<AuthCubit>()
+                            .loginByFamilyName(_familyName);
+                      },
+                    )
+                  : null,
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/features/school_event/screens/school_event_info_screen.dart
+++ b/lib/features/school_event/screens/school_event_info_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:givt_app_kids/core/app/pages.dart';
+import 'package:givt_app_kids/features/profiles/cubit/profiles_cubit.dart';
+import 'package:givt_app_kids/shared/widgets/givt_elevated_button.dart';
+import 'package:go_router/go_router.dart';
+
+class SchoolEventInfoScreen extends StatelessWidget {
+  const SchoolEventInfoScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    final activeProfile = context.watch<ProfilesCubit>().state.activeProfile;
+    return Scaffold(
+      appBar: AppBar(),
+      body: SafeArea(
+        child: SizedBox(
+          width: double.maxFinite,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              SizedBox(height: size.height * 0.1),
+              Text(
+                "Hi ${activeProfile.firstName} family!\nHere is",
+                textAlign: TextAlign.center,
+                style: Theme.of(context)
+                    .textTheme
+                    .headlineLarge
+                    ?.copyWith(fontWeight: FontWeight.w700),
+              ),
+              const SizedBox(height: 20),
+              Text(
+                "\$${activeProfile.wallet.balance}",
+                style: const TextStyle(fontSize: 77),
+              ),
+              const SizedBox(height: 30),
+              Text(
+                "to start\ngiving",
+                textAlign: TextAlign.center,
+                style: Theme.of(context)
+                    .textTheme
+                    .headlineLarge
+                    ?.copyWith(fontWeight: FontWeight.w700),
+              ),
+              SizedBox(height: size.height * 0.10),
+            ],
+          ),
+        ),
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      floatingActionButton: GivtElevatedButton(
+        text: 'Next',
+        onTap: () => context.goNamed(Pages.wallet.name),
+      ),
+    );
+  }
+}

--- a/lib/features/school_event/screens/school_event_organisations_screen.dart
+++ b/lib/features/school_event/screens/school_event_organisations_screen.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:givt_app_kids/features/exhibition_flow/widgets/organisation_item.dart';
+import 'package:givt_app_kids/features/profiles/cubit/profiles_cubit.dart';
+import 'package:givt_app_kids/features/profiles/widgets/coin_widget.dart';
+import 'package:givt_app_kids/features/recommendation/organisations/cubit/organisations_cubit.dart';
+import 'package:givt_app_kids/helpers/app_theme.dart';
+import 'package:givt_app_kids/helpers/snack_bar_helper.dart';
+import 'package:givt_app_kids/shared/widgets/givt_back_button.dart';
+import 'package:loading_animation_widget/loading_animation_widget.dart';
+
+class SchoolEventOrganisationsScreen extends StatelessWidget {
+  const SchoolEventOrganisationsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final user = context.read<ProfilesCubit>().state.activeProfile;
+
+    return BlocConsumer<OrganisationsCubit, OrganisationsState>(
+      listener: (context, state) {
+        if (state is OrganisationsExternalErrorState) {
+          SnackBarHelper.showMessage(
+            context,
+            text:
+                'Cannot load organizations. Please try again later. ${state.errorMessage}',
+            isError: true,
+          );
+        } else if (state is OrganisationsFetchedState) {
+          // AnalyticsHelper.logEvent(
+          //   eventName: AmplitudeEvent.charitiesShown,
+          //   eventProperties: {
+          //     AnalyticsHelper.recommendedCharitiesKey:
+          //         state.organisations.map((e) => e.name).toList().toString(),
+          //   },
+          // );
+        }
+      },
+      builder: (context, state) {
+        return Scaffold(
+          extendBodyBehindAppBar: true,
+          appBar: AppBar(
+            toolbarHeight: 0,
+            backgroundColor: Colors.transparent,
+            systemOverlayStyle: const SystemUiOverlayStyle(
+              statusBarColor: Colors.transparent,
+              statusBarIconBrightness: Brightness.light,
+            ),
+          ),
+          body: SafeArea(
+            child: CustomScrollView(
+              slivers: [
+                SliverAppBar(
+                  backgroundColor: Colors.transparent,
+                  automaticallyImplyLeading: false,
+                  leading: const GivtBackButton(),
+                  actions: [
+                    Row(
+                      children: [
+                        Text(
+                          '\$${user.wallet.balance.toStringAsFixed(0)}',
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                              fontSize: 22,
+                              fontFamily: 'Raleway',
+                              fontWeight: FontWeight.w900),
+                        ),
+                        const CoinWidget(),
+                      ],
+                    ),
+                  ],
+                ),
+                SliverPadding(
+                  padding: const EdgeInsets.only(top: 16),
+                  sliver: SliverAppBar(
+                    elevation: 4,
+                    pinned: true,
+                    backgroundColor: Colors.transparent,
+                    forceMaterialTransparency: true,
+                    automaticallyImplyLeading: false,
+                    toolbarHeight: 80,
+                    title: Container(
+                      padding: const EdgeInsets.all(10),
+                      decoration: BoxDecoration(
+                        color: Colors.white.withOpacity(0.85),
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: Text(
+                        state is OrganisationsFetchingState
+                            ? 'Loading...'
+                            : state.organisations.isEmpty
+                                ? 'Oops, something went wrong...'
+                                : 'Which organisation would you\nlike to give to?',
+                        textAlign: TextAlign.center,
+                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                              fontWeight: FontWeight.w700,
+                              fontFamily: 'Raleway',
+                              fontSize: 18,
+                            ),
+                      ),
+                    ),
+                  ),
+                ),
+                if (state is OrganisationsFetchingState)
+                  SliverFillViewport(delegate: SliverChildBuilderDelegate(
+                      (BuildContext context, int index) {
+                    return Padding(
+                      padding: EdgeInsets.symmetric(
+                          horizontal: MediaQuery.sizeOf(context).width * .3),
+                      child: LoadingAnimationWidget.waveDots(
+                          color: AppTheme.givt4KidsBlue, size: 100),
+                    );
+                  })),
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 24,
+                    vertical: 32,
+                  ),
+                  sliver: SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                      (BuildContext context, int index) {
+                        return OrganisationItem(
+                            organisation: state.organisations[index]);
+                      },
+                      childCount: state.organisations.length,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Description

- School event flow button placeholder added to the Login screen (temporary binded with example_feature_enabled remote config)
- LoggedIn auth state refactored: duplicate session removed, serialisation versioning added, school event mode flag storing added
- Login by family name logic added (dummy screen, design implementation required)
- School info dummy screen added (design implementation required)
- Fetching school event logic implemented but is not used yet since the corresponding endpoint is in progress 
- School event organisations screen (and bottom sheet with details) are implemented (but with recommendation flow fetching logic under the hood) 
- Success screen (coin version) text is updated
- GivtBackButton is slightly refactored (but still needs to be refactored a bit - kids-576)
- minor improvements  
