### PR TITLE
Improvement: Remove start button for NFC flow; Start scanning immediately

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,1 @@
+extensions:

--- a/lib/core/app/app_router.dart
+++ b/lib/core/app/app_router.dart
@@ -36,7 +36,6 @@ import 'package:givt_app_kids/features/recommendation/organisations/screens/orga
 import 'package:givt_app_kids/features/recommendation/start_recommendation/start_recommendation_screen.dart';
 import 'package:givt_app_kids/features/recommendation/tags/cubit/tags_cubit.dart';
 import 'package:givt_app_kids/features/recommendation/tags/screens/location_selection_screen.dart';
-import 'package:givt_app_kids/features/scan_nfc/cubit/scan_nfc_cubit.dart';
 import 'package:givt_app_kids/features/scan_nfc/nfc_scan_screen.dart';
 import 'package:givt_app_kids/features/school_event/screens/family_name_login_screen.dart';
 import 'package:givt_app_kids/features/school_event/screens/school_event_info_screen.dart';
@@ -277,7 +276,6 @@ class AppRouter {
           path: Pages.scanNFC.path,
           name: Pages.scanNFC.name,
           builder: (context, state) {
-            context.read<ScanNfcCubit>().resetScanNFCStatus();
             return const NFCScanPage();
           },
         ),

--- a/lib/features/scan_nfc/cubit/scan_nfc_cubit.dart
+++ b/lib/features/scan_nfc/cubit/scan_nfc_cubit.dart
@@ -36,10 +36,6 @@ class ScanNfcCubit extends Cubit<ScanNfcState> {
     }
   }
 
-  void resetScanNFCStatus() {
-    emit(state.copyWith(scanNFCStatus: ScanNFCStatus.ready));
-  }
-
   void readTag({Duration prescanningDelay = Duration.zero}) async {
     AnalyticsHelper.logEvent(eventName: AmplitudeEvent.startScanningCoin);
 

--- a/lib/features/scan_nfc/nfc_scan_screen.dart
+++ b/lib/features/scan_nfc/nfc_scan_screen.dart
@@ -18,8 +18,19 @@ import 'package:go_router/go_router.dart';
 
 import '../profiles/cubit/profiles_cubit.dart';
 
-class NFCScanPage extends StatelessWidget {
+class NFCScanPage extends StatefulWidget {
   const NFCScanPage({super.key});
+
+  @override
+  State<NFCScanPage> createState() => _NFCScanPageState();
+}
+
+class _NFCScanPageState extends State<NFCScanPage> {
+  @override
+  void initState() {
+    context.read<ScanNfcCubit>().readTag();
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

Acceptance Criteria
[x] No delay or start button when first pressing coin tile
[x] Start button should only be displayed if user selects cancel on NFC pop up