### PR TITLE
Impact group details dialog bg is white now (KIDS-897)

### DIFF
--- a/lib/features/impact_groups/dialogs/impact_group_details_description_dialog.dart
+++ b/lib/features/impact_groups/dialogs/impact_group_details_description_dialog.dart
@@ -34,7 +34,7 @@ class ImpactGroupDetailsDescriptionDialog extends StatelessWidget {
             borderRadius: BorderRadius.circular(25),
           ),
           color: Colors.white,
-          elevation: 7,
+          elevation: 0,
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [


### PR DESCRIPTION
## Description
- Elevation is set to 0 for the impact group details dialog
