### PR TITLE
Bugfix: Pop over balance should be 0

### DIFF
--- a/lib/features/profiles/screens/profile_screen.dart
+++ b/lib/features/profiles/screens/profile_screen.dart
@@ -83,7 +83,8 @@ class _ProfileScreenState extends State<ProfileScreen>
   @override
   Widget build(BuildContext context) {
     return BlocConsumer<ProfilesCubit, ProfilesState>(
-        listener: (context, state) => state.activeProfile.wallet.balance == 30
+        listener: (context, state) => state is ProfilesUpdatedState &&
+                state.activeProfile.wallet.balance == 0
             ? showDialog<void>(
                 context: context,
                 barrierDismissible: false,


### PR DESCRIPTION
## Description
<!--- Describe your changes -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated profile screen to display a dialog when the active profile's wallet balance is zero.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->